### PR TITLE
Add support for keywords as defined by GPX 1.1 Schema

### DIFF
--- a/GPX/GPXMetadata.h
+++ b/GPX/GPXMetadata.h
@@ -44,7 +44,7 @@
 @property (strong, nonatomic) NSDate *time;
 
 /** Keywords associated with the file. Search engines or databases can use this information to classify the data. */
-@property (strong, nonatomic) NSString *keyword;
+@property (strong, nonatomic) NSString *keywords;
 
 /** Minimum and maximum coordinates which describe the extent of the coordinates in the file. */
 @property (strong, nonatomic) GPXBounds *bounds;

--- a/GPX/GPXMetadata.m
+++ b/GPX/GPXMetadata.m
@@ -24,7 +24,7 @@
 @synthesize copyright = _copyright;
 @synthesize link = _link;
 @synthesize time = _time;
-@synthesize keyword = _keyword;
+@synthesize keywords = _keywords;
 @synthesize bounds = _bounds;
 @synthesize extensions = _extensions;
 
@@ -41,7 +41,7 @@
         _copyright = (GPXCopyright *)[self childElementOfClass:[GPXCopyright class] xmlElement:element];
         _link = (GPXLink *)[self childElementOfClass:[GPXLink class] xmlElement:element];
         _timeValue = [self textForSingleChildElementNamed:@"time" xmlElement:element];
-        _keyword = [self textForSingleChildElementNamed:@"keyword" xmlElement:element];
+        _keywords = [self textForSingleChildElementNamed:@"keywords" xmlElement:element];
         _bounds = (GPXBounds *)[self childElementOfClass:[GPXBounds class] xmlElement:element];
         _extensions = (GPXExtensions *)[self childElementOfClass:[GPXExtensions class] xmlElement:element];
     }
@@ -92,7 +92,7 @@
     }
 
     [self gpx:gpx addPropertyForValue:_timeValue defaultValue:@"0" tagName:@"time" indentationLevel:indentationLevel];
-    [self gpx:gpx addPropertyForValue:_keyword tagName:@"keyword" indentationLevel:indentationLevel];
+    [self gpx:gpx addPropertyForValue:_keywords tagName:@"keywords" indentationLevel:indentationLevel];
 
     if (self.bounds) {
         [self.bounds gpx:gpx indentationLevel:indentationLevel];

--- a/GPX/GPXRoot.m
+++ b/GPX/GPXRoot.m
@@ -58,10 +58,11 @@
     if (self) {
         _version = [self valueOfAttributeNamed:@"version" xmlElement:element required:YES] ?: _version;
         _creator = [self valueOfAttributeNamed:@"creator" xmlElement:element required:YES] ?: _creator;
-        _keywords = [GPXRoot keywordsArrayFromString:[self textForSingleChildElementNamed:@"keywords" xmlElement:element]];
-
         _metadata = (GPXMetadata *)[self childElementOfClass:[GPXMetadata class] xmlElement:element];
-        
+        _keywords = [GPXRoot keywordsArrayFromString:[self textForSingleChildElementNamed:@"keywords" xmlElement:element]];
+        if (!_keywords.count && _metadata.keywords.length) {
+            _keywords = [GPXRoot keywordsArrayFromString:_metadata.keywords];
+        }
         NSMutableArray *array1 = [NSMutableArray array];
         [self childElementsOfClass:[GPXWaypoint class]
                         xmlElement:element


### PR DESCRIPTION
Keywords in Schema 1.0 are placed inside GPX and were moved to the metadata field in http://www.topografix.com/GPX/1/1/