### PR TITLE
Add array type information to all GPX headers

### DIFF
--- a/GPX/GPXPointSegment.h
+++ b/GPX/GPXPointSegment.h
@@ -21,7 +21,7 @@
 /// ---------------------------------
 
 /** Ordered list of geographic points. */
-@property (strong, nonatomic, readonly) NSArray *points;
+@property (strong, nonatomic, readonly) NSArray<GPXPoint *> *points;
 
 
 /// ---------------------------------
@@ -48,7 +48,7 @@
 /** Adds the GPXPoint objects contained in another given array to the end of the point array.
  @param array An array of GPXPoint objects to add to the end of the point array.
  */
-- (void)addPoints:(NSArray *)array;
+- (void)addPoints:(NSArray<GPXPoint *> *)array;
 
 
 /// ---------------------------------

--- a/GPX/GPXRoot.h
+++ b/GPX/GPXRoot.h
@@ -44,15 +44,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, nullable, readonly) NSArray<NSString *> *keywords;
 
 /** A list of waypoints. */
-@property (strong, nonatomic, readonly) NSArray *waypoints;
+@property (strong, nonatomic, readonly) NSArray<GPXWaypoint *> *waypoints;
 
 /** A list of routes. */
-@property (strong, nonatomic, readonly) NSArray *routes;
+@property (strong, nonatomic, readonly) NSArray<GPXRoute *> *routes;
 
 /** A list of tracks. */
-@property (strong, nonatomic, readonly) NSArray *tracks;
+@property (strong, nonatomic, readonly) NSArray<GPXTrack *> *tracks;
 
-/** You can add extend GPX by adding your own elements from another schema here. */
+/** You can extend GPX by adding your own elements from another schema here. */
 @property (strong, nonatomic, nullable) GPXExtensions *extensions;
 
 
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** Adds the GPXWaypoint objects contained in another given array to the end of the waypoint array.
  @param array An array of GPXWaypoint objects to add to the end of the waypoint array.
  */
-- (void)addWaypoints:(NSArray *)array;
+- (void)addWaypoints:(NSArray<GPXWaypoint *> *)array;
 
 
 /// ---------------------------------
@@ -126,7 +126,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** Adds the GPXRoute objects contained in another given array to the end of the route array.
  @param array An array of GPXRoute objects to add to the end of the route array.
  */
-- (void)addRoutes:(NSArray *)array;
+- (void)addRoutes:(NSArray<GPXRoute *> *)array;
 
 
 /// ---------------------------------
@@ -161,7 +161,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** Adds the GPXTrack objects contained in another given array to the end of the track array.
  @param array An array of GPXTrack objects to add to the end of the track array.
  */
-- (void)addTracks:(NSArray *)array;
+- (void)addTracks:(NSArray<GPXTrack *> *)array;
 
 
 /// ---------------------------------

--- a/GPX/GPXRoute.h
+++ b/GPX/GPXRoute.h
@@ -35,7 +35,7 @@
 @property (strong, nonatomic) NSString *source;
 
 /** Links to external information about the route. */
-@property (strong, nonatomic, readonly) NSArray *links;
+@property (strong, nonatomic, readonly) NSArray<GPXLink *> *links;
 
 /** GPS route number. */
 @property (nonatomic, assign) NSInteger number;
@@ -47,7 +47,7 @@
 @property (strong, nonatomic) GPXExtensions *extensions;
 
 /** A list of route points. */
-@property (strong, nonatomic, readonly) NSArray *routepoints;
+@property (strong, nonatomic, readonly) NSArray<GPXRoutePoint *> *routepoints;
 
 
 /// ---------------------------------
@@ -73,7 +73,7 @@
 /** Adds the GPXLink objects contained in another given array to the end of the link array.
  @param array An array of GPXLink objects to add to the end of the link array.
  */
-- (void)addLinks:(NSArray *)array;
+- (void)addLinks:(NSArray<GPXLink *> *)array;
 
 
 /// ---------------------------------
@@ -110,7 +110,7 @@
 /** Adds the GPXRoutePoint objects contained in another given array to the end of the routepoint array.
  @param array An array of GPXRoutePoint objects to add to the end of the routepoint array.
  */
-- (void)addRoutepoints:(NSArray *)array;
+- (void)addRoutepoints:(NSArray<GPXRoutePoint *> *)array;
 
 
 /// ---------------------------------

--- a/GPX/GPXTrack.h
+++ b/GPX/GPXTrack.h
@@ -36,7 +36,7 @@
 @property (strong, nonatomic) NSString *source;
 
 /** Links to external information about track. */
-@property (strong, nonatomic, readonly) NSArray *links;
+@property (strong, nonatomic, readonly) NSArray<GPXLink *> *links;
 
 /** GPS track number. */
 @property (nonatomic) NSInteger number;
@@ -50,7 +50,7 @@
 /** A Track Segment holds a list of Track Points which are logically connected in order.
     To represent a single GPS track where GPS reception was lost, or the GPS receiver was turned off, 
     start a new Track Segment for each continuous span of track data. */
-@property (strong, nonatomic, readonly) NSArray *tracksegments;
+@property (strong, nonatomic, readonly) NSArray<GPXTrackSegment *> *tracksegments;
 
 
 /// ---------------------------------
@@ -76,7 +76,7 @@
 /** Adds the GPXLink objects contained in another given array to the end of the link array.
  @param array An array of GPXLink objects to add to the end of the link array.
  */
-- (void)addLinks:(NSArray *)array;
+- (void)addLinks:(NSArray<GPXLink *> *)array;
 
 
 /// ---------------------------------
@@ -111,7 +111,7 @@
 /** Adds the GPXTrackSegment objects contained in another given array to the end of the tracksegment array.
  @param array An array of GPXTrackSegment objects to add to the end of the tracksegment array.
  */
-- (void)addTracksegments:(NSArray *)array;
+- (void)addTracksegments:(NSArray<GPXTrackSegment *> *)array;
 
 
 /// ---------------------------------

--- a/GPX/GPXTrackSegment.h
+++ b/GPX/GPXTrackSegment.h
@@ -23,7 +23,7 @@
 /// ---------------------------------
 
 /** A Track Point holds the coordinates, elevation, timestamp, and metadata for a single point in a track. */
-@property (strong, nonatomic, readonly) NSArray *trackpoints;
+@property (strong, nonatomic, readonly) NSArray<GPXTrackPoint *> *trackpoints;
 
 /** You can add extend GPX by adding your own elements from another schema here. */
 @property (strong, nonatomic) GPXExtensions *extensions;
@@ -53,7 +53,7 @@
 /** Adds the GPXTrackPoint objects contained in another given array to the end of the trackpoint array.
  @param array An array of GPXTrackPoint objects to add to the end of the trackpoint array.
  */
-- (void)addTrackpoints:(NSArray *)array;
+- (void)addTrackpoints:(NSArray<GPXTrackPoint *> *)array;
 
 
 /// ---------------------------------

--- a/GPX/GPXWaypoint.h
+++ b/GPX/GPXWaypoint.h
@@ -136,7 +136,7 @@
 /** Adds the GPXLink objects contained in another given array to the end of the link array.
  @param array An array of GPXLink objects to add to the end of the link array.
  */
-- (void)addLinks:(NSArray *)array;
+- (void)addLinks:(NSArray<GPXLink *> *)array;
 
 
 /// ---------------------------------


### PR DESCRIPTION
Was a byproduct of something else I tried. I guess it's worth keeping.